### PR TITLE
SSM API 呼び出しをキャッシュできてなかったのを修正

### DIFF
--- a/infra/src/access-control/fetchParams.ts
+++ b/infra/src/access-control/fetchParams.ts
@@ -48,5 +48,5 @@ export const fetchParams = async (prefix: string) => {
     ),
   ]);
 
-  return { userPoolId, userPoolAppId, userPoolDomain };
+  return memo = { userPoolId, userPoolAppId, userPoolDomain };
 };


### PR DESCRIPTION
誰も `memo` に書き込みに行っていなかった