### PR TITLE
fix: no-redundant-template-literal description

### DIFF
--- a/packages/eslint-plugin/rules/no-redundant-template-literal.js
+++ b/packages/eslint-plugin/rules/no-redundant-template-literal.js
@@ -4,7 +4,7 @@ const rule = {
     type: "problem",
     docs: {
       description:
-        "children: ReactNode should be replaced with PropsWithChildren.",
+        "Template literal with single expression should be replaced with String casting.",
     },
     fixable: "code",
     schema: [],


### PR DESCRIPTION
#227 のミス修正